### PR TITLE
INFRA-3063: Docker image retention logic

### DIFF
--- a/cleanup/cleanDockerImages/CleanDockerImagesTest.groovy
+++ b/cleanup/cleanDockerImages/CleanDockerImagesTest.groovy
@@ -9,11 +9,11 @@ class CleanDockerImagesTest extends Specification {
         setup:
         def baseurl = 'http://localhost:8088/artifactory'
         def artifactory = ArtifactoryClientBuilder.create().setUrl(baseurl)
-            .setUsername('admin').setPassword('password').build()
+                .setUsername('admin').setPassword('password').build()
 
         def builder = artifactory.repositories().builders()
         def local = builder.localRepositoryBuilder().key('example-docker-local')
-            .repositorySettings(new DockerRepositorySettingsImpl()).build()
+                .repositorySettings(new DockerRepositorySettingsImpl()).build()
         artifactory.repositories().create(0, local)
         def repo = artifactory.repository('example-docker-local')
         mkImage(repo, 'foo1/bar/manifest.json', 'text1', 1)
@@ -91,7 +91,7 @@ class CleanDockerImagesTest extends Specification {
     }
 
     void mkImage(repo, path, content, ct) {
-        def prop = 'docker.label.com.jfrog.artifactory.retention.maxCount'
+        def prop = 'docker.label.com.joom.retention.maxCount'
         def stream = new ByteArrayInputStream(content.getBytes('utf-8'))
         repo.upload(path, stream).doUpload()
         repo.file(path).properties().addProperty(prop, "$ct").doSet()

--- a/cleanup/cleanDockerImages/README.md
+++ b/cleanup/cleanDockerImages/README.md
@@ -12,10 +12,13 @@ The `cleanDockerImages.properties` file has the following field:
 - `dockerRepos`: A list of Docker repositories to clean. If a repo is not in
   this list, it will not be cleaned.
 
+- `defaultMaxDays`: A default value for `maxDays` for images without `maxCount`.
+
 For example:
 
 ``` json
 dockerRepos = ["example-docker-local", "example-docker-local-2"]
+defaultMaxDays = 3
 ```
 
 Usage
@@ -24,17 +27,22 @@ Usage
 Cleanup policies are specified as labels on the Docker image. Currently, this
 plugin supports the following policies:
 
+- `expireDate` property: This image should be removed after this date.
+  If `expireDate` property is exists, all other policies is ignored.
+- `pullProtectDays`: Image would be protected for deleting after last
+  pull.
 - `maxDays`: The maximum number of days a Docker image can exist in an
   Artifactory repository. Any images older than this will be deleted.
 - `maxCount`: The maximum number of versions of a particular image which should
   exist. For example, if there are 10 versions of a Docker image and `maxCount`
   is set to 6, the oldest 4 versions of the image will be deleted.
 
+
 To set these labels for an image, add them to the Dockerfile before building:
 
 ``` dockerfile
-LABEL com.jfrog.artifactory.retention.maxCount="10"
-LABEL com.jfrog.artifactory.retention.maxDays="7"
+LABEL com.joom.retention.maxCount="10"
+LABEL com.joom.retention.maxDays="7"
 ```
 
 When a Docker image is deployed, Artifactory will automatically create

--- a/cleanup/cleanDockerImages/cleanDockerImages.properties
+++ b/cleanup/cleanDockerImages/cleanDockerImages.properties
@@ -1,1 +1,2 @@
 dockerRepos = ["example-docker-local"]
+defaultMaxDays = 3


### PR DESCRIPTION
Правила чистки:

- если у Docker-образа есть Artifactory Property `com.joom.retention.expireDate=YYYY-MM-DD,` и указанная дата в прошлом, то образ удаляется;
 - если у Docker-образа есть Artifactory Property `com.joom.retention.expireDate=YYYY-MM-DD`, и указанная дата не в прошлом, то образ остаётся;
 - если указан Docker LABEL `com.joom.retention.pullProtectDays=N`, и дата последней скачки образа была менее N дней назад, то образ остаётся;
 - если указан Docker LABEL `com.joom.retention.maxDays=N`, и дата создания образа была более N дней назад, то образ удаляется;
 - если указан Docker LABEL `com.joom.retention.maxCount=N`, и есть более N более свежих образов от той же группы, то образ удаляется. Имя группы берется из Docker LABEL 
com.joom.retention.maxCountGroup (если не указана - то группа - пустая строка);
 - если не указано никаких параметров, то образ ведёт себя так, будто `com.joom.retention.maxDays=3`.

Для `pullProtectDays` и `maxDays` значение -1 трактуется как "хранить вечно".

На первый взгляд оно должно работать, но надо бы немного погонять в dry run.